### PR TITLE
Fix login guard redirection

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -90,7 +90,7 @@ router.beforeEach((to, from, next) => {
 
     // Check if route requires authentication
     if (to.meta.requiresAuth && !isLoggedIn) {
-        next({ name: 'login' });
+        next({ name: 'Login' });
         return;
     }
 


### PR DESCRIPTION
## Summary
- correct route name when redirecting to login page

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `pnpm type-check` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_6848047b27588331b2913099c775ede2